### PR TITLE
registry.svc.ci is no longer used, replaced by registry.ci

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,9 +1,9 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.19-openshift-4.11 AS builder
 WORKDIR /src/kubevirt-csi-driver
 COPY . .
 RUN make build
 
-FROM registry.svc.ci.openshift.org/ocp/4.7:base
+FROM registry.ci.openshift.org/ocp/4.11:base
 
 RUN yum install -y e2fsprogs xfsprogs && yum clean all
 COPY --from=builder /src/kubevirt-csi-driver/kubevirt-csi-driver .

--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.19-openshift-4.11 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.12 AS builder
 WORKDIR /src/kubevirt-csi-driver
 COPY . .
 RUN make build

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -5,8 +5,11 @@ aliases:
       - aglitke
       - ydayagi
       - rgolangh
+      - davidvossel
+      - nunnatsa
   code-reviewers:
       - aglitke
       - ydayagi
       - rgolangh
-
+      - davidvossel
+      - nunnatsa


### PR DESCRIPTION
Fixes the openshift dockerfile so images can be built again. This is blocking several prs becaue prow can't pass until this is resolved.

This also adds new owners so we can move forward quicker with future changes like this.

blocks
https://github.com/openshift/kubevirt-csi-driver/pull/9
https://github.com/openshift/release/pull/31469

```release-note
NONE
```

