### PR TITLE
CNV-45886: Add csi-clone support to kubevirt-csi (#118)

### DIFF
--- a/hack/test-driver.yaml
+++ b/hack/test-driver.yaml
@@ -15,6 +15,7 @@ DriverInfo:
     persistence: true
     singleNodeVolume: false
     snapshotDataSource: true
+    pvcDataSource: true
     topology: false
     capacity: false
     RWX: false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Adds csi-clone support for kubevirt-csi-driver by passing the clone request directly to the underlying infra storage. This will only succeed if the underlying storage also supports csi-clone.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
enabled csi-clone for kubevirt-csi-driver
```

