### PR TITLE
OCPBUGS-44350: During detach don't return error if VM is not found

### DIFF
--- a/pkg/service/controller.go
+++ b/pkg/service/controller.go
@@ -447,6 +447,10 @@ func (c *ControllerService) ControllerUnpublishVolume(ctx context.Context, req *
 	// Get VM name
 	vmName, err := c.getVMNameByCSINodeID(ctx, req.NodeId)
 	if err != nil {
+		if status.Code(err) == codes.NotFound {
+			klog.Infof("VM for node ID %s not found, assuming volume is already detached", req.NodeId)
+			return &csi.ControllerUnpublishVolumeResponse{}, nil
+		}
 		return nil, err
 	}
 

--- a/pkg/service/controller_test.go
+++ b/pkg/service/controller_test.go
@@ -349,6 +349,13 @@ var _ = Describe("PublishUnPublish", func() {
 		_, err := controller.ControllerUnpublishVolume(context.TODO(), getUnpublishVolumeRequest())
 		Expect(err).ToNot(HaveOccurred())
 	})
+
+	It("should return success when unpublishing a volume from a VM that doesn't exist", func() {
+		req := getUnpublishVolumeRequest()
+		req.NodeId = "non-existent-node"
+		_, err := controller.ControllerUnpublishVolume(context.TODO(), req)
+		Expect(err).ToNot(HaveOccurred())
+	})
 })
 
 var _ = Describe("Snapshots", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
When detaching a volume from a VM, the VM might not be found if it was deleted for whatever reason at this point we can assume the volume is no longer hotplugged, and thus the detach succeeded by default

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://issues.redhat.com/browse/OCPBUGS-44350

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix volume attachment not being cleaned up on VM node reboot in kubevirt-csi-driver
```

