### PR TITLE
Remove rgolangh from OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -5,12 +5,10 @@ aliases:
       - aglitke
       - awels
       - ydayagi
-      - rgolangh
       - davidvossel
       - nunnatsa
   code-reviewers:
       - aglitke
       - ydayagi
-      - rgolangh
       - davidvossel
       - nunnatsa


### PR DESCRIPTION
Removed 'rgolangh' from approvers and code-reviewers.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

